### PR TITLE
fix: add coupon_share_url

### DIFF
--- a/response/tbkdgmaterialoptional.go
+++ b/response/tbkdgmaterialoptional.go
@@ -51,6 +51,7 @@ type TbkDgMaterialOptionalMapDatum struct {
 	Provcity             string                           `json:"provcity"`
 	ReservePrice         string                           `json:"reserve_price"`
 	SellerID             int64                            `json:"seller_id"`
+	Nick                 string                           `json:"nick"`
 	ShopDsr              int64                            `json:"shop_dsr"`
 	ShopTitle            string                           `json:"shop_title"`
 	ShortTitle           string                           `json:"short_title"`

--- a/response/tbkdgmaterialoptional.go
+++ b/response/tbkdgmaterialoptional.go
@@ -40,6 +40,10 @@ type TbkDgMaterialOptionalMapDatum struct {
 	CouponShareURL       string                           `json:"coupon_share_url"`
 	CouponRemainCount    int64                            `json:"coupon_remain_count"`
 	CouponTotalCount     int64                            `json:"coupon_total_count"`
+	CouponStartTime      string                           `json:"coupon_start_time"`
+	CouponEndTime        string                           `json:"coupon_end_time"`
+	CouponStartFee       string                           `json:"coupon_start_fee"`
+	CouponAmount         string                           `json:"coupon_amount"`
 	IncludeDxjh          string                           `json:"include_dxjh"`
 	IncludeMkt           string                           `json:"include_mkt"`
 	InfoDxjh             string                           `json:"info_dxjh"`

--- a/response/tbkdgmaterialoptional.go
+++ b/response/tbkdgmaterialoptional.go
@@ -37,6 +37,7 @@ type TbkDgMaterialOptionalMapDatum struct {
 	CommissionType       string                           `json:"commission_type"`
 	CouponID             string                           `json:"coupon_id"`
 	CouponInfo           string                           `json:"coupon_info"`
+	CouponShareURL       string                           `json:"coupon_share_url"`
 	CouponRemainCount    int64                            `json:"coupon_remain_count"`
 	CouponTotalCount     int64                            `json:"coupon_total_count"`
 	IncludeDxjh          string                           `json:"include_dxjh"`


### PR DESCRIPTION
## What does this PR do?

- add fields to `TbkDgMaterialOptionalMapDatum`:

  - `coupon_share_url`
  - `coupon_start_time`
  - `coupon_end_time`
  - `coupon_start_fee`
  - `coupon_amount`
  - `nick`

## Request to review & merge

@mimicode 